### PR TITLE
Add postBuild for lab extensions

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,4 @@
+ipython kernel install --name widgets-tutorial --display-name widgets-tutorial --sys-prefix
+
+jupyter labextension install @jupyter-widgets/jupyterlab-manager @jupyter-widgets/jupyterlab-sidecar bqplot jupyter-threejs jupyter-leaflet@0.12.6 ipysheet ipytree ipycanvas jupyter-matplotlib jupyter-vuetify ipyvolume --no-build
+jupyter lab build --minimize=False


### PR DESCRIPTION
Including the `--minimize=False` to avoid memory issues when running `jupyter lab build`.